### PR TITLE
Experience Points for Opponents Defeated (Basic Rules)

### DIFF
--- a/Halberds-and-Helmets.ltx
+++ b/Halberds-and-Helmets.ltx
@@ -941,6 +941,9 @@ levels.\marginnote[-6em]{As gold turns into experience, the pursuit of
   act of bringing the loot back to safety can be a problem if you are
   weakened and heavily loaded on your way back to town.}
 
+Gold (and thus xp) can be passed to other characters as long as the
+recipient's level is \emph{the same or lower}.
+
 \key{Level}: As time passes, characters hit better, get better saving
 throws and gain hit points. They \emph{gain a level}.
 
@@ -1034,6 +1037,10 @@ character: 7 + charisma bonus. If they roll higher than their morale,
 these retainers retire. \marginnote[-3em]{\hyperref[sec:wages]{Wages}
   must be paid at the end of the session.}
 
+Retainers gain experience points like a player character; by defeating
+opponents and spending money. \index{Gold!Retainers}Retainers will
+spend their money as quickly as possible.
+
 The \emph{fair share} for a retainer is half of what the player
 character gained.\marginnote{The
   \href{https://en.wikipedia.org/wiki/Pirate_code}{pirate code} worked
@@ -1053,13 +1060,6 @@ characters and their retainers.
   \centering
   \includegraphics[height=4cm]{Beckenhaube.jpg}
 \end{marginfigure}
-
-Retainers gain experience points like a player character. Money from
-wages and treasure can be turned into experience points.
-
-Gold (and thus xp) can be passed to other characters as long as the
-recipient's level is \emph{the same or lower}.\index{Gold!Retainers}
-Retainers spend their money as quickly as possible.
 
 
 


### PR DESCRIPTION
[**You may not want to merge this patch, I created it mainly as a forum for discussion.**]

Only the first paragraph seems directly related to the title. Perhaps the remaining paragraphs should be distributed between “Experience Points (xp)” and “Retainers”. This patch has one proposal of how it could be done. However, note that the added text breaks the page layout so some additional massaging would be necessary if you want to go this route.


